### PR TITLE
add file duplicate option through per-file actions popover in sidebar (mvp?)

### DIFF
--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -22,6 +22,7 @@ import {
     SidebarIcon,
     UndoIcon,
 } from './components/icons';
+import { useOptHeld } from './opt-held';
 import { shouldReduceMotion } from '../uikit/animation';
 import { DirPopover } from '../uikit/dir-popover';
 import { Button } from '../uikit/button';
@@ -654,27 +655,9 @@ function SaveButton({
     disabled: boolean;
     onSave: (format?: string) => void;
 }) {
-    const [optHeld, setOptHeld] = useState(false);
+    const optHeld = useOptHeld();
     const [isMouseOver, setMouseOver] = useState(false);
     const [formatPickerOpen, setFormatPickerOpen] = useState(false);
-
-    const setOptHeldRef = useRef(setOptHeld);
-    setOptHeldRef.current = setOptHeld;
-    useEffect(() => {
-        const onKeyDown = (e: KeyboardEvent) => {
-            setOptHeldRef.current(e.altKey);
-        };
-        const onKeyUp = (e: KeyboardEvent) => {
-            setOptHeldRef.current(e.altKey);
-        };
-
-        window.addEventListener('keydown', onKeyDown);
-        window.addEventListener('keyup', onKeyUp);
-        return () => {
-            window.removeEventListener('keydown', onKeyDown);
-            window.removeEventListener('keyup', onKeyUp);
-        };
-    }, []);
 
     const save = (e: React.MouseEvent) => {
         if (e.altKey) {

--- a/src/ui/opt-held.tsx
+++ b/src/ui/opt-held.tsx
@@ -1,0 +1,25 @@
+import { useEffect, useRef, useState } from 'react';
+
+export function useOptHeld(): boolean {
+    const [optHeld, setOptHeld] = useState(false);
+
+    const setOptHeldRef = useRef(setOptHeld);
+    setOptHeldRef.current = setOptHeld;
+    useEffect(() => {
+        const onKeyDown = (e: KeyboardEvent) => {
+            setOptHeldRef.current(e.altKey);
+        };
+        const onKeyUp = (e: KeyboardEvent) => {
+            setOptHeldRef.current(e.altKey);
+        };
+
+        window.addEventListener('keydown', onKeyDown);
+        window.addEventListener('keyup', onKeyUp);
+        return () => {
+            window.removeEventListener('keydown', onKeyDown);
+            window.removeEventListener('keyup', onKeyUp);
+        };
+    }, []);
+
+    return optHeld;
+}

--- a/src/ui/sidebar.css
+++ b/src/ui/sidebar.css
@@ -145,7 +145,8 @@
                 }
             }
 
-            &:not(.is-selected) > .i-file:hover {
+            &:not(.is-selected) > .i-file:hover,
+            > .i-file.actions-open {
                 background: var(--sidebar-item-hover);
             }
 
@@ -223,6 +224,33 @@
                     > .i-label:hover {
                         background: var(--danger-content-fg);
                         color: var(--danger);
+                    }
+                }
+            }
+
+            .i-actions {
+                display: flex;
+                padding: 0;
+                margin: 0;
+                list-style: none;
+                border-top: 1px solid var(--separator);
+
+                & li {
+                    flex: 1;
+
+                    & button {
+                        background: none;
+                        border: none;
+                        color: inherit;
+                        font: inherit;
+
+                        &:active {
+                            opacity: 0.5;
+                        }
+                    }
+
+                    & + li {
+                        border-left: 1px solid var(--separator);
                     }
                 }
             }


### PR DESCRIPTION
## what?
i've ended up with a bit of a workflow
1. opening prechoster
2. create a new file
3. add a style inliner
4. add two text modules (one for html, one for css)
5. wire it all up

the templates are lovely, but i usually feel like starting with a much more blank slate. the theory-crafting went like this:
- i should add a template for my use case
  - wouldn't it be nice if you could create your own local templates?
    - actually, i probably just want a way to duplicate files

## how?
while getting acquainted with the codebase i discovered the "hold opt to get more options" feature of the save button, and so thought i'd use the same technique to add a duplicate option onto each file in an unobtrusive way.

![](https://github.com/cpsdqs/prechoster/assets/7885480/fe79ec47-4db2-46b5-ac9a-5f78427aacd1)

## mvp?
this is mostly a mvp, because there are a few things that i think should be ironed out:
- discoverability isn't great
  - i'd use the ellipsis as in the save button, but this doesn't interact well with the existing ellipsis for Long Titles
- i stole the css for the `<ul>` of buttons in the popover from save
  - i'm not sure how much of it is relevant, and if the styling works for you
  - atm, it looks pretty good for more than one button
    - tried to brainstorm some other things that could potentially be added to the popover
    - wasn't super successful but it seemed Not Unlikely
- refactored to move the opt key tracking into a `useOptHold`
  - i'm not sure where this should go.
  - it's just in `opt-hold.tsx` in `ui/` right now
- naming? `.actions-open` class
  - not sure your preferences on class names
- i think this makes it easier to trigger #8 somehow

if you've got feedback on any of these things, i'm happy to tackle them myself (even like, move the ui to somewhere else/bigger changes to support this)

thanks for making prechoster 🐶
